### PR TITLE
fix surf2vol error when input face havs 5 columns

### DIFF
--- a/iso2mesh/core.py
+++ b/iso2mesh/core.py
@@ -661,9 +661,9 @@ def surf2vol(node, face, xi, yi, zi, **kwargs):
         if face.shape[1] == 5:
             label = 1
             el = face
-            face = np.empty((0, 4))
+            face = np.empty((0, 4), dtype="int64")
             for lbl in elabel:
-                fc = volface(el[el[:, 4] == lbl, :4])
+                fc, _ = volface(el[el[:, 4] == lbl, :4])
                 fc = np.hstack((fc, np.full((fc.shape[0], 1), lbl)))
                 face = np.vstack((face, fc))
     else:


### PR DESCRIPTION
The surf2vol function return error when input face is 5 columns (tetrahedral mesh with label). The error comes from two places:
1, Line 664: 
```python 
face = np.empty((0, 4)) # face should be interger array
``` 
create float array by deafult, which cause line 728 error
2, Line 666:
```python
fc = volface(el[el[:, 4] == lbl, :4]) # fc should be the face array, not truple
```
`volface`return two value: openface and elemid. so fc here will be a truple and cause line 667 error. I guess here we just need the face.

Fix:
1, line 664: `face = np.empty((0, 4), dtype="int64")` 
2, line 666: `fc, _ = volface(el[el[:, 4] == lbl, :4])`